### PR TITLE
Add coverage to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
 test
 waltz.jpg
 logo.png
-
+coverage


### PR DESCRIPTION
Don't need coverage stats in built npm packages.