### PR TITLE
Add the `errorLevel` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,12 +22,21 @@ var LogDriver = function(options){
       logger[level] = function(){
         var args = Array.prototype.slice.call(arguments);
         args.unshift(level);  // log level is added as the first parameter
-        console.log(logger.format.apply(logger, args));
+        var write = getWriter(level, options.errorLevel, logger.levels);
+        write(logger.format.apply(logger, args));
       };
     } else {
       logger[level] = function(){/* no-op, because this log level is ignored */};
     }
   });
+};
+
+var getWriter = function(logLevel, errorLevel, levels){
+  // Note: If 'levels' does not contain 'errorLevel', then 'console.log'
+  //       is used.
+  return errorLevel &&
+    (levels.indexOf(logLevel) <= levels.indexOf(errorLevel)) ?
+      console.error : console.log;
 };
 
 var logLevelShouldOutput = function(logLevel, configuredLevel, levels){

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,8 @@ var should = require('should');
 var logger = require('../index');
 var defaultLogger = require('../index').logger;
 var sinon = require('sinon-restore');
-var logged = "";
 var oldConsoleLog = console.log;
+var oldConsoleError = console.error;
 
 /* NOTE: console.log is mocked in these tests, so any uses of it will be
  * appended to the variabled "logged".  This will include any calls you
@@ -15,16 +15,24 @@ var oldConsoleLog = console.log;
 
 
 describe("logdriver", function(){
+  var logged;
+  var errored;
   beforeEach(function(){
-    logged = "";
+    logged = [];
+    errored = [];
     sinon.stub(console, 'log', function(str){
-      logged += str + "\n";
+      logged.push(str);
+    });
+    sinon.stub(console, 'error', function(str){
+      errored.push(str);
     });
   });
   afterEach(function(){
     sinon.restoreAll();
     console.log = oldConsoleLog;
-    logged = "";
+    console.error = oldConsoleError;
+    logged = [];
+    errored = [];
   });
   it ("provides a default instance of logger with default levels", function(){
     var mylogger = defaultLogger;
@@ -42,31 +50,28 @@ describe("logdriver", function(){
                                'whocares']});
     should.exist(mylogger.superimportant);
   });
-  it ("allows log level to be specified, and doesn't log below that level", function(){
+  it ("allows you to specify a log level of false to suppress all output", function(){
     var mylogger = logger({ level : false});
     mylogger.info("info test"); 
     mylogger.warn("warn test"); 
     mylogger.error("error test"); 
     mylogger.trace("trace test"); 
-    logged.should.equal('');
+    logged.should.have.lengthOf(0);
   });
-  it ("allows you to specify a log level of false to suppress all output", function(){
+  it ("allows log level to be specified, and doesn't log below that level", function(){
     var mylogger = logger({ level : 'info'});
     mylogger.info("info test"); 
     mylogger.warn("warn test"); 
     mylogger.error("error test"); 
     mylogger.trace("trace test"); 
-    var lines = logged.split("\n");
-    lines[0].should.include('[info]');
-    lines[1].should.include('[warn]');
-    lines[2].should.include('[error]');
-    lines[0].should.include('info test');
-    lines[1].should.include('warn test');
-    lines[2].should.include('error test');
-
+    logged.should.have.lengthOf(3);
+    logged[0].should.include('[info]');
+    logged[1].should.include('[warn]');
+    logged[2].should.include('[error]');
+    logged[0].should.include('info test');
+    logged[1].should.include('warn test');
+    logged[2].should.include('error test');
   });
-
-
   it ("allows you to override the default format", function(){
     var mylogger = logger({
       format : function(){
@@ -74,6 +79,56 @@ describe("logdriver", function(){
       }
     });
     mylogger.error("here's an error");
-    JSON.parse(logged).should.eql({"0":"error","1":"here's an error"});
+    JSON.parse(logged[0]).should.eql({"0":"error","1":"here's an error"});
+  });
+
+  it ("outputs all using console.log if errorLevel is not specified", function(){
+    var mylogger = logger({
+      // everything with level 'info' and below is logged
+      level: 'info',
+      levels: ['fatal', 'error', 'warn', 'info']});
+    mylogger.fatal("fatal test");
+    mylogger.error("error test");
+    mylogger.warn("warn test");
+    mylogger.info("info test");
+
+    logged.should.have.lengthOf(4);
+    errored.should.have.lengthOf(0);
+  });
+
+  it("outputs all using console.log if errorLevel is invalid", function() {
+    var mylogger = logger({
+      level: 'info',
+      errorLevel: 'not in levels list',
+      levels: ['fatal', 'error', 'warn', 'info']});
+    mylogger.fatal("fatal test");
+    mylogger.error("error test");
+    mylogger.warn("warn test");
+    mylogger.info("info test");
+
+    logged.should.have.lengthOf(4);
+    errored.should.have.lengthOf(0);
+  });
+
+  it ("will use console.error if errorLevel is specified", function(){
+    var mylogger = logger({
+      // everything with level 'info' and below is logged
+      level: 'info',
+      // everything with level 'error' and below is logged to standard error
+      // everything with level above 'error' is logged to standard out
+      errorLevel: 'error',
+      levels: ['fatal', 'error', 'warn', 'info']});
+    mylogger.fatal("fatal test");
+    mylogger.error("error test");
+    mylogger.warn("warn test");
+    mylogger.info("info test");
+
+    logged.should.have.lengthOf(2);
+    logged[0].should.include("warn test");
+    logged[1].should.include("info test");
+
+    errored.should.have.lengthOf(2);
+    errored[0].should.include("fatal test");
+    errored[1].should.include("error test");
   });
 });


### PR DESCRIPTION
This option, if specified, indicates at which log level, and
below, logs should be printed to standard error instead of
standard output.